### PR TITLE
Generate vote txs and rename `generate` to `tx push`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.idea
+multisig
+config.toml
+unsigned.json

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Generate a `unsigned.json` tx as you normally would for the given multisig addre
 Then run
 
 ```
-multisig tx push--tx unsigned.json --node <node address> <chain name> <key name>
+multisig tx push --tx unsigned.json --node <node address> <chain name> <key name>
 ```
 
 This will push the `unsigned.json` to the directory in the s3 bucket for the specified chain and key (ie. `/<chain name>/<key name>/0`). 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Quick summary, with much more below:
 - All signers have access to the entire s3 bucket, and can read/write at will, so assumption is they are all
   trusted
 - `multisig tx push` takes an unsigned tx file and pushes it to the s3 directory along with data needed for signing (eg. account number, sequence number, chain id)
+- `multisig tx vote` generate a vote tx and push it to s3 directory
 - `multisig sign` fetches the unsigned tx and signing data for a given chain and key, signs it using the correct binary (eg. `gaiad tx sign unsigned.json ...`), and pushes the signature back to the directory
 - `multisig list` lists the files in a directory so you can see who has signed
 - `multisig broadcast` fetches all the data from a directory, compiles the signed tx (eg. `gaiad tx multisign unsigned.json ...`), broadcasts it using the configured node, and deletes all the files from the directory so signing can start fresh for a new tx
@@ -163,20 +164,20 @@ node = "http://localhost:26657" # a synced node - only needed for `tx` and `broa
 
 Commands:
 
-- Generate
-- List
-- Sign
-- Broadcast
-- Raw
+- Tx - `multisig tx`
+- List - `multisig list`
+- Sign - `multisig sign`
+- Broadcast - `multisig broadcast`
+- Raw - `multisig raw`
 
-### Generate
+## Tx
 
-Generate a `unsigned.json` tx as you normally would for the given multisig address with any of the chain binaries.
+The multisig tx command allows you to push transactions to S3. You can push `unsigned.json` transactions that are manually generated
+or you can use commands to generate the transactions and push it automatically to S3.
 
-Then run
-
+### tx push
 ```
-multisig tx push --tx unsigned.json --node <node address> <chain name> <key name>
+multisig tx push <chain name> <key name>
 ```
 
 This will push the `unsigned.json` to the directory in the s3 bucket for the specified chain and key (ie. `/<chain name>/<key name>/0`). 
@@ -186,8 +187,10 @@ and push a file to the bucket called `signdata.json` containing the account numb
 The sequence and account number can be overwriten or specified without a node
 using the `--sequence` and `--account` flags
 
-Note if you use `--node` its shelling out to the `<binary> query account <address>`
-command and parsing the response.
+> Note: if you use `--node` its shelling out to the `<binary> query account <address>`
+command and parsing the response. 
+
+This assumes that the `<binary>` (e.g gaiad) is properly installed on the machine and accessible (can be executed from a command prompt e.g. `$> gaiad`) . The `<binary>` name is retrieved from the config.toml file.
 
 To push multiple txs for the same chain and key, use the `--additional` flag.
 Each additional tx will increment the path suffix and the sequence number. For
@@ -206,7 +209,16 @@ cosmos/my-key/1/unsigned.json
 
 To overwrite the first tx, use `--force`.
 
-### List
+### tx vote
+
+```
+multisig tx vote <chain name> <key name> <proposal number> <vote option> [flags]
+```
+
+This will generate a tx for a governance proposal vote and it will push it to s3 directly. You will need to specify the proposal number and the vote (e.g. yes, no). 
+You will also need to specify the denom for the fees (e.g. uatom) if it cannot be retrieved from a node.
+
+## List
 
 To see the files in the directory of a chain and key:
 
@@ -239,7 +251,7 @@ osmosis/mycorp-main/0/unsigned.json
 This shows all the chain/key pairs that have been setup. All of them are empty
 except `osmosis/mycorp-main` which has one signature (`eb.json`).
 
-### Sign
+## Sign
 
 To sign a tx:
 
@@ -250,7 +262,7 @@ index>
 
 Where `--from` is the name of the key in your local keystore, the same as you would provide to `--from` in `gaiad` or other Cosmos-SDK binaries, and `--index` is the tx index to sign for (default 0).
 
-### Broadcast
+## Broadcast
 
 To assemble the signed tx and broadcast it, run:
 
@@ -263,7 +275,7 @@ broadcast in order.
 
 The `--node` flag can be used to overwrite what's in the config file.
 
-### Raw
+## Raw
 
 There are a set of `raw` subcommands for direct manipulation of bucket objects.
 This is mostly for debugging purposes and generally should not need to be used.
@@ -271,12 +283,12 @@ See `multisig raw --help` and the help menu for each subcommand for more info.
 
 ## TODO
 
-High Priority
+### High Priority
 
 - make config globally accessible eg. in `~/.multisig/config.toml`
 - add denoms to chains and have `tx push` validate txs are using correct denoms
 - tx push should check fees and gas are high enough
-- add multisig threshold to the config and ensure theres enough signatures
+- add multisig threshold to the config and ensure there is enough signatures
   before broadcasting
 - convenience commands to generate voting and reward withdrawal txs 
 - `tx push` should include a description that can be displayed in the `list` so signers know what each tx is doing
@@ -286,7 +298,7 @@ High Priority
 - use `--broadcast-mode block` ?
 - new command to show unclaimed rewards for all addresses on all networks
 
-Mid Priority
+### Mid Priority
 
 - simulate tx to estimate gas
 - add a command for porting a multisig from one binary's keystore to another
@@ -300,7 +312,7 @@ Mid Priority
   available than rest ? )
 
 
-Lower Priority
+### Lower Priority
 
 - Use the https://github.com/cosmos/chain-registry for configuring chains instead of the
   config.toml ?

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Quick summary, with much more below:
 - Create a directory in the bucket for each chain and key, like `/<chain name>/<key name>/`
 - All signers have access to the entire s3 bucket, and can read/write at will, so assumption is they are all
   trusted
-- `multisig generate` takes a generated unsigned tx file and pushes it to the s3 directory along with data needed for signing (eg. account number, sequence number, chain id)
+- `multisig tx push` takes an unsigned tx file and pushes it to the s3 directory along with data needed for signing (eg. account number, sequence number, chain id)
 - `multisig sign` fetches the unsigned tx and signing data for a given chain and key, signs it using the correct binary (eg. `gaiad tx sign unsigned.json ...`), and pushes the signature back to the directory
 - `multisig list` lists the files in a directory so you can see who has signed
 - `multisig broadcast` fetches all the data from a directory, compiles the signed tx (eg. `gaiad tx multisign unsigned.json ...`), broadcasts it using the configured node, and deletes all the files from the directory so signing can start fresh for a new tx
@@ -156,7 +156,7 @@ name = "cosmos"                 # name of the chain
 binary = "gaiad"                # name of binary
 prefix = "cosmos"               # bech32 prefix
 id = "cosmoshub-4"              # chain-id
-node = "http://localhost:26657" # a synced node - only needed for `generate` and `broadcast` commands
+node = "http://localhost:26657" # a synced node - only needed for `tx` and `broadcast` commands
 ```
 
 ## Run
@@ -176,7 +176,7 @@ Generate a `unsigned.json` tx as you normally would for the given multisig addre
 Then run
 
 ```
-multisig generate --tx unsigned.json --node <node address> <chain name> <key name>
+multisig tx push--tx unsigned.json --node <node address> <chain name> <key name>
 ```
 
 This will push the `unsigned.json` to the directory in the s3 bucket for the specified chain and key (ie. `/<chain name>/<key name>/0`). 
@@ -274,12 +274,12 @@ See `multisig raw --help` and the help menu for each subcommand for more info.
 High Priority
 
 - make config globally accessible eg. in `~/.multisig/config.toml`
-- add denoms to chains and have `generate` validate txs are using correct denoms
-- generate should check fees and gas are high enough
+- add denoms to chains and have `tx push` validate txs are using correct denoms
+- tx push should check fees and gas are high enough
 - add multisig threshold to the config and ensure theres enough signatures
   before broadcasting
 - convenience commands to generate voting and reward withdrawal txs 
-- `generate` should include a description that can be displayed in the `list` so signers know what each tx is doing
+- `tx push` should include a description that can be displayed in the `list` so signers know what each tx is doing
 - `broadcast` should log the tx once its complete (maybe a log file
   in each top level chain directory?) - should include the key, tx id, and the description 
 - need a way to assign local key names (`--from`) to keys (possibly on a per-chain basis, eek)

--- a/cmd.go
+++ b/cmd.go
@@ -17,12 +17,28 @@ var rootCmd = &cobra.Command{
 	},
 }
 
-var generateCmd = &cobra.Command{
-	Use:   "generate <chain name> <key name>",
+var txCmd = &cobra.Command{
+	Use:   "tx",
 	Short: "generate a new unsigned tx",
+	// Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+	},
+}
+
+var pushCmd = &cobra.Command{
+	Use:   "push <chain name> <key name>",
+	Short: "push the given unsigned tx with associated signing metadata",
 	Long:  "if a tx already exists for this chain and key, it will start using prefixes",
 	Args:  cobra.ExactArgs(2),
-	RunE:  cmdGenerate,
+	RunE:  cmdPush,
+}
+
+var voteCmd = &cobra.Command{
+	Use:   "vote <chain name> <key name> <proposal number> <vote option (yes/no/veto/abstain)>",
+	Short: "generate a vote tx and push it",
+	Args:  cobra.ExactArgs(4),
+	RunE:  cmdVote,
 }
 
 var signCmd = &cobra.Command{
@@ -108,7 +124,7 @@ var (
 )
 
 func init() {
-	rootCmd.AddCommand(generateCmd)
+	rootCmd.AddCommand(txCmd)
 	rootCmd.AddCommand(signCmd)
 	rootCmd.AddCommand(listCmd)
 	rootCmd.AddCommand(broadcastCmd)
@@ -121,13 +137,16 @@ func init() {
 	rawCmd.AddCommand(rawMkdirCmd)
 	rawCmd.AddCommand(rawDeleteCmd)
 
-	generateCmd.Flags().StringVarP(&flagTx, "tx", "t", "", "unsigned tx file")
-	generateCmd.MarkFlagRequired("tx")
-	generateCmd.Flags().IntVarP(&flagSequence, "sequence", "s", 0, "sequence number for the tx")
-	generateCmd.Flags().IntVarP(&flagAccount, "account", "a", 0, "account number for the tx")
-	generateCmd.Flags().StringVarP(&flagNode, "node", "n", "", "tendermint rpc node to get sequence and account number from")
-	generateCmd.Flags().BoolVarP(&flagForce, "force", "f", false, "overwrite files already there")
-	generateCmd.Flags().BoolVarP(&flagAdditional, "additional", "x", false, "add additional txs with higher sequence number")
+	txCmd.AddCommand(pushCmd)
+	txCmd.AddCommand(voteCmd)
+
+	txCmd.Flags().StringVarP(&flagTx, "tx", "t", "", "unsigned tx file")
+	txCmd.MarkFlagRequired("tx")
+	txCmd.Flags().IntVarP(&flagSequence, "sequence", "s", 0, "sequence number for the tx")
+	txCmd.Flags().IntVarP(&flagAccount, "account", "a", 0, "account number for the tx")
+	txCmd.Flags().StringVarP(&flagNode, "node", "n", "", "tendermint rpc node to get sequence and account number from")
+	txCmd.Flags().BoolVarP(&flagForce, "force", "f", false, "overwrite files already there")
+	txCmd.Flags().BoolVarP(&flagAdditional, "additional", "x", false, "add additional txs with higher sequence number")
 
 	signCmd.Flags().IntVarP(&flagTxIndex, "index", "i", 0, "index of the tx to sign")
 	signCmd.Flags().StringVarP(&flagFrom, "from", "f", "", "name of your local key to sign with")

--- a/cmd.go
+++ b/cmd.go
@@ -6,7 +6,7 @@ import (
 
 // TODO: something more intelligent
 // Remember to change this every time ...
-const VERSION = "0.1.0"
+const VERSION = "0.2.0"
 
 var rootCmd = &cobra.Command{
 	Use:     "multisig",

--- a/cmd.go
+++ b/cmd.go
@@ -120,6 +120,7 @@ var (
 	flagForce       bool
 	flagAdditional  bool
 	flagDescription string
+	flagDenom       string
 	flagTxIndex     int
 )
 
@@ -140,13 +141,20 @@ func init() {
 	txCmd.AddCommand(pushCmd)
 	txCmd.AddCommand(voteCmd)
 
-	txCmd.Flags().StringVarP(&flagTx, "tx", "t", "", "unsigned tx file")
-	txCmd.MarkFlagRequired("tx")
-	txCmd.Flags().IntVarP(&flagSequence, "sequence", "s", 0, "sequence number for the tx")
-	txCmd.Flags().IntVarP(&flagAccount, "account", "a", 0, "account number for the tx")
-	txCmd.Flags().StringVarP(&flagNode, "node", "n", "", "tendermint rpc node to get sequence and account number from")
-	txCmd.Flags().BoolVarP(&flagForce, "force", "f", false, "overwrite files already there")
-	txCmd.Flags().BoolVarP(&flagAdditional, "additional", "x", false, "add additional txs with higher sequence number")
+	pushCmd.Flags().StringVarP(&flagTx, "tx", "t", "", "unsigned tx file")
+	pushCmd.MarkFlagRequired("tx")
+	pushCmd.Flags().IntVarP(&flagSequence, "sequence", "s", 0, "sequence number for the tx")
+	pushCmd.Flags().IntVarP(&flagAccount, "account", "a", 0, "account number for the tx")
+	pushCmd.Flags().StringVarP(&flagNode, "node", "n", "", "tendermint rpc node to get sequence and account number from")
+	pushCmd.Flags().BoolVarP(&flagForce, "force", "f", false, "overwrite files already there")
+	pushCmd.Flags().BoolVarP(&flagAdditional, "additional", "x", false, "add additional txs with higher sequence number")
+
+	voteCmd.Flags().StringVarP(&flagDenom, "denom", "d", "", "fee denom, for offline creation")
+	voteCmd.Flags().IntVarP(&flagSequence, "sequence", "s", 0, "sequence number for the tx")
+	voteCmd.Flags().IntVarP(&flagAccount, "account", "a", 0, "account number for the tx")
+	voteCmd.Flags().StringVarP(&flagNode, "node", "n", "", "tendermint rpc node to get sequence and account number from")
+	voteCmd.Flags().BoolVarP(&flagForce, "force", "f", false, "overwrite files already there")
+	voteCmd.Flags().BoolVarP(&flagAdditional, "additional", "x", false, "add additional txs with higher sequence number")
 
 	signCmd.Flags().IntVarP(&flagTxIndex, "index", "i", 0, "index of the tx to sign")
 	signCmd.Flags().StringVarP(&flagFrom, "from", "f", "", "name of your local key to sign with")

--- a/main.go
+++ b/main.go
@@ -110,6 +110,7 @@ func cmdVote(cmd *cobra.Command, args []string) error {
 		"--fees", fmt.Sprintf("%d%s", fee, denom),
 		"--gas", fmt.Sprintf("%d", gas),
 		"--generate-only",
+		"--chain-id", fmt.Sprintf("%s", chain.ID),
 	}
 	// TODO: do we need these?
 	// cmdArgs = append(cmdArgs, "--keyring-backend", backend)

--- a/main.go
+++ b/main.go
@@ -67,6 +67,19 @@ func cmdVote(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("key %s not found in config", keyName)
 	}
 
+	nodeAddress := chain.Node
+	if flagNode != "" {
+		nodeAddress = flagNode
+	}
+
+	isDenomSet := cmd.Flags().Changed("denom")
+
+	noNode := nodeAddress == ""
+	if !isDenomSet && noNode {
+		fmt.Println("if --denom is not provided, a node must be specified in the config or with --node")
+		return nil
+	}
+
 	// TODO:
 	// node address?
 	// keyring backend?
@@ -81,11 +94,14 @@ func cmdVote(cmd *cobra.Command, args []string) error {
 	gas := 300000
 	fee := 10000
 
-	// XXX: get the denom
-	// this is a massive hack. use the chain-registry instead :D
-	denom, err := getDenom(binary)
-	if err != nil {
-		return err
+	denom := flagDenom
+	if flagNode != "" {
+		// XXX: get the denom
+		// this is a massive hack. use the chain-registry instead :D
+		denom, err = getDenom(binary, flagNode)
+		if err != nil {
+			return err
+		}
 	}
 
 	// gaiad tx gov vote <prop id> <option> --from <from> --generate-only

--- a/util.go
+++ b/util.go
@@ -9,8 +9,8 @@ import (
 // XXX: get the denom
 // this is a massive hack. use the chain-registry instead :D
 // this just calls `<binary> query staking params` and parses out the staking token denom
-func getDenom(binary string) (string, error) {
-	cmdArgs := []string{"query", "staking", "params"}
+func getDenom(binary string, node string) (string, error) {
+	cmdArgs := []string{"query", "staking", "params", "--node", node}
 	execCmd := exec.Command(binary, cmdArgs...)
 	b, err := execCmd.CombinedOutput()
 	if err != nil {

--- a/util.go
+++ b/util.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// XXX: get the denom
+// this is a massive hack. use the chain-registry instead :D
+// this just calls `<binary> query staking params` and parses out the staking token denom
+func getDenom(binary string) (string, error) {
+	cmdArgs := []string{"query", "staking", "params"}
+	execCmd := exec.Command(binary, cmdArgs...)
+	b, err := execCmd.CombinedOutput()
+	if err != nil {
+		fmt.Println("-----------------------------------------------------------------")
+		fmt.Println("call failed")
+		fmt.Println("-----------------------------------------------------------------")
+		fmt.Println(execCmd)
+		fmt.Println(string(b))
+		return "", err
+	}
+	fmt.Println(string(b))
+	s := strings.Split(string(b), "\n")
+	firstLine := s[0]
+
+	s2 := strings.Split(firstLine, " ")
+	denom := strings.TrimSpace(s2[1])
+
+	return denom, nil
+}


### PR DESCRIPTION
- Changes the `multisig generate` command to `multisig tx push` 
- Add new `multisig tx vote` command that creates an unsinged vote tx and pushes it