### PR TITLE
Replace --tx flag param with a positional argument for unsigned tx file in `tx push` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,10 +177,10 @@ or you can use commands to generate the transactions and push it automatically t
 
 ### tx push
 ```
-multisig tx push <chain name> <key name>
+multisig tx push <unsigned tx file> <chain name> <key name>
 ```
 
-This will push the `unsigned.json` to the directory in the s3 bucket for the specified chain and key (ie. `/<chain name>/<key name>/0`). 
+This will push the unsigned tx file (`e.g unsigned.json`) to the directory in the s3 bucket for the specified chain and key (ie. `/<chain name>/<key name>/0`). 
 
 It will also fetch the account number and sequence number from the given `--node <node address>`,
 and push a file to the bucket called `signdata.json` containing the account number, sequence number, and chain ID.
@@ -216,6 +216,15 @@ multisig tx vote <chain name> <key name> <proposal number> <vote option> [flags]
 ```
 
 This will generate a tx for a governance proposal vote and it will push it to s3 directly. You will need to specify the proposal number and the vote (e.g. yes, no). 
+You will also need to specify the denom for the fees (e.g. uatom) if it cannot be retrieved from a node.
+
+### tx withdraw
+
+```
+multisig tx withdraw <chain name> <key name>
+```
+
+This will generate a tx for withdraw all rewards for the account, and it will push it to s3 directly.
 You will also need to specify the denom for the fees (e.g. uatom) if it cannot be retrieved from a node.
 
 ## List

--- a/cmd.go
+++ b/cmd.go
@@ -27,10 +27,10 @@ var txCmd = &cobra.Command{
 }
 
 var pushCmd = &cobra.Command{
-	Use:   "push <chain name> <key name>",
+	Use:   "push <unsigned tx file> <chain name> <key name>",
 	Short: "push the given unsigned tx with associated signing metadata",
 	Long:  "if a tx already exists for this chain and key, it will start using prefixes",
-	Args:  cobra.ExactArgs(2),
+	Args:  cobra.ExactArgs(3),
 	RunE:  cmdPush,
 }
 
@@ -149,8 +149,6 @@ func init() {
 	txCmd.AddCommand(voteCmd)
 	txCmd.AddCommand(withdrawCmd)
 
-	pushCmd.Flags().StringVarP(&flagTx, "tx", "t", "", "unsigned tx file")
-	pushCmd.MarkFlagRequired("tx")
 	pushCmd.Flags().IntVarP(&flagSequence, "sequence", "s", 0, "sequence number for the tx")
 	pushCmd.Flags().IntVarP(&flagAccount, "account", "a", 0, "account number for the tx")
 	pushCmd.Flags().StringVarP(&flagNode, "node", "n", "", "tendermint rpc node to get sequence and account number from")

--- a/main.go
+++ b/main.go
@@ -204,7 +204,7 @@ func cmdVote(cmd *cobra.Command, args []string) error {
 	if !noNode {
 		cmdArgs = append(cmdArgs, "--node", nodeAddress)
 	}
-	
+
 	// TODO: do we need these?
 	// cmdArgs = append(cmdArgs, "--keyring-backend", backend)
 	// cmdArgs = append(cmdArgs, "--node", nodeAddress)
@@ -225,11 +225,10 @@ func cmdVote(cmd *cobra.Command, args []string) error {
 }
 
 func cmdPush(cmd *cobra.Command, args []string) error {
-	chainName := args[0]
-	keyName := args[1]
+	txFile := args[0]
+	chainName := args[1]
+	keyName := args[2]
 
-	// read the unsigned tx file
-	txFile := flagTx
 	unsignedBytes, err := ioutil.ReadFile(txFile)
 	if err != nil {
 		return err


### PR DESCRIPTION
closes: #8 

Replaced the `--tx` flag for `tx push` with a positional argument for the `unsigned tx file`. So now the command is:

```
Usage:
  multisig tx push <unsigned tx file> <chain name> <key name> [flags]

Flags:
  -a, --account int    account number for the tx
  -x, --additional     add additional txs with higher sequence number
  -f, --force          overwrite files already there
  -h, --help           help for push
  -n, --node string    tendermint rpc node to get sequence and account number from
  -s, --sequence int   sequence number for the tx
```

This ensures the user specifies the file and it's the right one. It's also a better UX in my opinion. 

Also updated the `README` to reflect this change

> NOTE: I've also updated the `README` to include the new `tx withdraw` command that forgot to add in the last PR