### PR TITLE
Refactored flags for commands

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -58,6 +58,7 @@ var signCmd = &cobra.Command{
 var listCmd = &cobra.Command{
 	Use:   "list <chain name> <key name>",
 	Short: "list items in a directory",
+	Args:  cobra.ExactArgs(2),
 	RunE:  cmdList,
 }
 
@@ -132,12 +133,14 @@ var (
 )
 
 func init() {
+	// Main commands
 	rootCmd.AddCommand(txCmd)
 	rootCmd.AddCommand(signCmd)
 	rootCmd.AddCommand(listCmd)
 	rootCmd.AddCommand(broadcastCmd)
 	rootCmd.AddCommand(rawCmd)
 
+	// Raw commands
 	rawCmd.AddCommand(rawBech32Cmd)
 	rawCmd.AddCommand(rawCatCmd)
 	rawCmd.AddCommand(rawUpCmd)
@@ -145,37 +148,23 @@ func init() {
 	rawCmd.AddCommand(rawMkdirCmd)
 	rawCmd.AddCommand(rawDeleteCmd)
 
+	// Tx subcommands
 	txCmd.AddCommand(pushCmd)
 	txCmd.AddCommand(voteCmd)
 	txCmd.AddCommand(withdrawCmd)
 
-	pushCmd.Flags().IntVarP(&flagSequence, "sequence", "s", 0, "sequence number for the tx")
-	pushCmd.Flags().IntVarP(&flagAccount, "account", "a", 0, "account number for the tx")
-	pushCmd.Flags().StringVarP(&flagNode, "node", "n", "", "tendermint rpc node to get sequence and account number from")
-	pushCmd.Flags().BoolVarP(&flagForce, "force", "f", false, "overwrite files already there")
-	pushCmd.Flags().BoolVarP(&flagAdditional, "additional", "x", false, "add additional txs with higher sequence number")
+	// Add flags to commands
+	addTxCmdCommonFlags(pushCmd)
 
-	voteCmd.Flags().StringVarP(&flagDenom, "denom", "d", "", "fee denom, for offline creation")
-	voteCmd.Flags().IntVarP(&flagSequence, "sequence", "s", 0, "sequence number for the tx")
-	voteCmd.Flags().IntVarP(&flagAccount, "account", "a", 0, "account number for the tx")
-	voteCmd.Flags().StringVarP(&flagNode, "node", "n", "", "tendermint rpc node to get sequence and account number from")
-	voteCmd.Flags().BoolVarP(&flagForce, "force", "f", false, "overwrite files already there")
-	voteCmd.Flags().BoolVarP(&flagAdditional, "additional", "x", false, "add additional txs with higher sequence number")
+	addTxCmdCommonFlags(voteCmd)
+	addDenomFlags(voteCmd)
 
-	withdrawCmd.Flags().StringVarP(&flagDenom, "denom", "d", "", "fee denom, for offline creation")
-	withdrawCmd.Flags().IntVarP(&flagSequence, "sequence", "s", 0, "sequence number for the tx")
-	withdrawCmd.Flags().IntVarP(&flagAccount, "account", "a", 0, "account number for the tx")
-	withdrawCmd.Flags().StringVarP(&flagNode, "node", "n", "", "tendermint rpc node to get sequence and account number from")
-	withdrawCmd.Flags().BoolVarP(&flagForce, "force", "f", false, "overwrite files already there")
-	withdrawCmd.Flags().BoolVarP(&flagAdditional, "additional", "x", false, "add additional txs with higher sequence number")
+	addTxCmdCommonFlags(withdrawCmd)
+	addDenomFlags(withdrawCmd)
 
-	signCmd.Flags().IntVarP(&flagTxIndex, "index", "i", 0, "index of the tx to sign")
-	signCmd.Flags().StringVarP(&flagFrom, "from", "f", "", "name of your local key to sign with")
-	signCmd.MarkFlagRequired("from")
+	addSignCmdFlags(signCmd)
 
-	listCmd.Flags().BoolVarP(&flagAll, "all", "a", false, "list files for all chains and keys")
+	addListCmdFlags(listCmd)
 
-	broadcastCmd.Flags().StringVarP(&flagNode, "node", "n", "", "node address to broadcast too. flag overrides config")
-	broadcastCmd.Flags().IntVarP(&flagTxIndex, "index", "i", 0, "index of the tx to broadcast")
-	// broacastCmd.Flags().StringVarP(&flagDescription, "description", "d", "", "description of the tx to be logged")
+	addBroadcastCmdFlags(broadcastCmd)
 }

--- a/flags.go
+++ b/flags.go
@@ -1,0 +1,36 @@
+package main
+
+import "github.com/spf13/cobra"
+
+// addTxCmdCommonFlags defines common flags to be reused across tx commands
+func addTxCmdCommonFlags(cmd *cobra.Command) {
+	cmd.Flags().IntVarP(&flagSequence, "sequence", "s", 0, "sequence number for the tx")
+	cmd.Flags().IntVarP(&flagAccount, "account", "a", 0, "account number for the tx")
+	cmd.Flags().StringVarP(&flagNode, "node", "n", "", "tendermint rpc node to get sequence and account number from")
+	cmd.Flags().BoolVarP(&flagForce, "force", "f", false, "overwrite files already there")
+	cmd.Flags().BoolVarP(&flagAdditional, "additional", "x", false, "add additional txs with higher sequence number")
+}
+
+// addDenomFlags defines a denom flag to be reused across commands
+func addDenomFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&flagDenom, "denom", "d", "", "fee denom, for offline creation")
+}
+
+// addSignCmdFlags defines common flags to be used in the sign command
+func addSignCmdFlags(cmd *cobra.Command) {
+	cmd.Flags().IntVarP(&flagTxIndex, "index", "i", 0, "index of the tx to sign")
+	cmd.Flags().StringVarP(&flagFrom, "from", "f", "", "name of your local key to sign with")
+	cmd.MarkFlagRequired("from")
+}
+
+// addListCmdFlags defines common flags to be used in the list command
+func addListCmdFlags(cmd *cobra.Command) {
+	cmd.Flags().BoolVarP(&flagAll, "all", "a", false, "list files for all chains and keys")
+}
+
+// addBroadcastCmdFlags defines common flags to be used in the broadcast command
+func addBroadcastCmdFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&flagNode, "node", "n", "", "node address to broadcast too. flag overrides config")
+	cmd.Flags().IntVarP(&flagTxIndex, "index", "i", 0, "index of the tx to broadcast")
+	// broacastCmd.Flags().StringVarP(&flagDescription, "description", "d", "", "description of the tx to be logged")
+}


### PR DESCRIPTION
closes #7 

Refactored the logic for the commands flags. They are grouped and declared on a separate file. This refactor might make it easier to re-use some common group of flags across commands (e.g. tx push, tx vote, tx withdraw)