### PR TITLE
Retrieve denom from config or the chain registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ name = "cosmos"                 # name of the chain
 binary = "gaiad"                # name of binary
 prefix = "cosmos"               # bech32 prefix
 id = "cosmoshub-4"              # chain-id
+denom = "uatom"                 # denom used to pay fees
 node = "http://localhost:26657" # a synced node - only needed for `tx` and `broadcast` commands
 ```
 
@@ -216,7 +217,8 @@ multisig tx vote <chain name> <key name> <proposal number> <vote option> [flags]
 ```
 
 This will generate a tx for a governance proposal vote and it will push it to s3 directly. You will need to specify the proposal number and the vote (e.g. yes, no). 
-You will also need to specify the denom for the fees (e.g. uatom) if it cannot be retrieved from a node.
+You will also need to specify the denom for the fees (e.g. uatom) if it cannot be retrieved from the configuration file or the 
+chain registry.
 
 ### tx withdraw
 
@@ -225,7 +227,8 @@ multisig tx withdraw <chain name> <key name>
 ```
 
 This will generate a tx for withdraw all rewards for the account, and it will push it to s3 directly.
-You will also need to specify the denom for the fees (e.g. uatom) if it cannot be retrieved from a node.
+You will also need to specify the denom for the fees (e.g. uatom) if it cannot be retrieved from the configuration file or the
+chain registry.
 
 ## List
 

--- a/config.go
+++ b/config.go
@@ -15,6 +15,7 @@ type Chain struct {
 	Prefix string // bech32 address prefix
 	ID     string // chain id for signing
 	Node   string // node to broadcast signed txs to
+	Denom  string // denom used for fees
 }
 
 // A key we sign txs with

--- a/main.go
+++ b/main.go
@@ -65,9 +65,18 @@ func cmdWithdraw(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("key %s not found in config", keyName)
 	}
 
-	denom, err := getDenom(conf, chainName)
-	if err != nil {
-		return fmt.Errorf("denom not found in config or chain registry: %s", err)
+	// Use denom from flag if specified, if not, then try
+	// to retrieve it from the config, if not in the config
+	// try to retrieve from the chain registry.
+	var denom string
+	isDenomSet := cmd.Flags().Changed("denom")
+	if isDenomSet {
+		denom = flagDenom
+	} else {
+		denom, err = getDenom(conf, chainName)
+		if err != nil {
+			return fmt.Errorf("denom not found in config or chain registry: %s", err)
+		}
 	}
 
 	nodeAddress := chain.Node
@@ -140,9 +149,18 @@ func cmdVote(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("key %s not found in config", keyName)
 	}
 
-	denom, err := getDenom(conf, chainName)
-	if err != nil {
-		return fmt.Errorf("denom not found in config or chain registry: %s", err)
+	// Use denom from flag if specified, if not, then try
+	// to retrieve it from the config, if not in the config
+	// try to retrieve from the chain registry.
+	var denom string
+	isDenomSet := cmd.Flags().Changed("denom")
+	if isDenomSet {
+		denom = flagDenom
+	} else {
+		denom, err = getDenom(conf, chainName)
+		if err != nil {
+			return fmt.Errorf("denom not found in config or chain registry: %s", err)
+		}
 	}
 
 	nodeAddress := chain.Node

--- a/main.go
+++ b/main.go
@@ -65,21 +65,17 @@ func cmdWithdraw(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("key %s not found in config", keyName)
 	}
 
+	denom, err := getDenom(conf, chainName)
+	if err != nil {
+		return fmt.Errorf("denom not found in config or chain registry: %s", err)
+	}
+
 	nodeAddress := chain.Node
 	if flagNode != "" {
 		nodeAddress = flagNode
 	}
 
-	isDenomSet := cmd.Flags().Changed("denom")
-
-	noNode := nodeAddress == ""
-	if !isDenomSet && noNode {
-		fmt.Println("if --denom is not provided, a node must be specified in the config or with --node")
-		return nil
-	}
-
 	// TODO:
-	// node address?
 	// keyring backend?
 
 	binary := chain.Binary
@@ -92,16 +88,6 @@ func cmdWithdraw(cmd *cobra.Command, args []string) error {
 	gas := 300000
 	fee := 10000
 
-	denom := flagDenom
-	if flagNode != "" {
-		// XXX: get the denom
-		// this is a massive hack. use the chain-registry instead :D
-		denom, err = getDenom(binary, flagNode)
-		if err != nil {
-			return err
-		}
-	}
-
 	// gaiad tx gov vote <prop id> <option> --from <from> --generate-only
 	cmdArgs := []string{"tx", "distribution", "withdraw-all-rewards",
 		"--from", address,
@@ -111,13 +97,12 @@ func cmdWithdraw(cmd *cobra.Command, args []string) error {
 		"--chain-id", fmt.Sprintf("%s", chain.ID),
 	}
 
-	if !noNode {
+	if nodeAddress != "" {
 		cmdArgs = append(cmdArgs, "--node", nodeAddress)
 	}
 
 	// TODO: do we need these?
 	// cmdArgs = append(cmdArgs, "--keyring-backend", backend)
-	// cmdArgs = append(cmdArgs, "--node", nodeAddress)
 	execCmd := exec.Command(binary, cmdArgs...)
 	fmt.Println(execCmd)
 	unsignedBytes, err := execCmd.CombinedOutput()
@@ -155,21 +140,17 @@ func cmdVote(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("key %s not found in config", keyName)
 	}
 
+	denom, err := getDenom(conf, chainName)
+	if err != nil {
+		return fmt.Errorf("denom not found in config or chain registry: %s", err)
+	}
+
 	nodeAddress := chain.Node
 	if flagNode != "" {
 		nodeAddress = flagNode
 	}
 
-	isDenomSet := cmd.Flags().Changed("denom")
-
-	noNode := nodeAddress == ""
-	if !isDenomSet && noNode {
-		fmt.Println("if --denom is not provided, a node must be specified in the config or with --node")
-		return nil
-	}
-
 	// TODO:
-	// node address?
 	// keyring backend?
 
 	binary := chain.Binary
@@ -182,16 +163,6 @@ func cmdVote(cmd *cobra.Command, args []string) error {
 	gas := 300000
 	fee := 10000
 
-	denom := flagDenom
-	if flagNode != "" {
-		// XXX: get the denom
-		// this is a massive hack. use the chain-registry instead :D
-		denom, err = getDenom(binary, flagNode)
-		if err != nil {
-			return err
-		}
-	}
-
 	// gaiad tx gov vote <prop id> <option> --from <from> --generate-only
 	cmdArgs := []string{"tx", "gov", "vote", propID, voteOption,
 		"--from", address,
@@ -201,13 +172,12 @@ func cmdVote(cmd *cobra.Command, args []string) error {
 		"--chain-id", fmt.Sprintf("%s", chain.ID),
 	}
 
-	if !noNode {
+	if nodeAddress != "" {
 		cmdArgs = append(cmdArgs, "--node", nodeAddress)
 	}
 
 	// TODO: do we need these?
 	// cmdArgs = append(cmdArgs, "--keyring-backend", backend)
-	// cmdArgs = append(cmdArgs, "--node", nodeAddress)
 	execCmd := exec.Command(binary, cmdArgs...)
 	fmt.Println(execCmd)
 	unsignedBytes, err := execCmd.CombinedOutput()

--- a/main.go
+++ b/main.go
@@ -222,6 +222,18 @@ func cmdPush(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	conf, err := loadConfig(configFile)
+	if err != nil {
+		return err
+	}
+
+	// Logic to emit a warning if the denoms don't match
+	denomInJson, err := parseDenomFromJson(unsignedBytes)
+	denomConfig, err := getDenom(conf, chainName)
+	if denomInJson != denomConfig {
+		fmt.Printf("WARNING: Denom '%s' in the unsigned json is different from the denom '%s' in the config or registry!\n", denomInJson, denomConfig)
+	}
+
 	return pushTx(chainName, keyName, unsignedBytes, cmd)
 }
 

--- a/util.go
+++ b/util.go
@@ -1,32 +1,27 @@
 package main
 
 import (
+	"errors"
 	"fmt"
-	"os/exec"
-	"strings"
 )
 
-// XXX: get the denom
-// this is a massive hack. use the chain-registry instead :D
-// this just calls `<binary> query staking params` and parses out the staking token denom
-func getDenom(binary string, node string) (string, error) {
-	cmdArgs := []string{"query", "staking", "params", "--node", node}
-	execCmd := exec.Command(binary, cmdArgs...)
-	b, err := execCmd.CombinedOutput()
-	if err != nil {
-		fmt.Println("-----------------------------------------------------------------")
-		fmt.Println("call failed")
-		fmt.Println("-----------------------------------------------------------------")
-		fmt.Println(execCmd)
-		fmt.Println(string(b))
-		return "", err
+// getDenom get the denom to be used in transaction fees
+// This method first will try to retrieve the denom from the configuration '[[chains]] denom'
+// if the deno	m is not available in the configuration then it will try to retrieve it from
+// the chain-registry (https://github.com/cosmos/chain-registry). But in order for the chain
+// registry retrieval to work, the chain name in the configuration file has to match the
+// chain_name property in the chain.json. For example
+// https://github.com/cosmos/chain-registry/blob/5ebdb2cf8bf0a6a14d602d4e63fd046f66895cbb/cosmoshub/chain.json#L3
+func getDenom(conf *Config, chainName string) (string, error) {
+	chain, found := conf.GetChain(chainName)
+	if !found {
+		return "", errors.New(fmt.Sprintf("chain %s not found in config", chainName))
+	} else {
+		if chain.Denom != "" {
+			return chain.Denom, nil
+		} else {
+			// Try chain registry
+			return "", errors.New(fmt.Sprintf("cannot find denom in the config or registry"))
+		}
 	}
-	fmt.Println(string(b))
-	s := strings.Split(string(b), "\n")
-	firstLine := s[0]
-
-	s2 := strings.Split(firstLine, " ")
-	denom := strings.TrimSpace(s2[1])
-
-	return denom, nil
 }

--- a/util.go
+++ b/util.go
@@ -96,3 +96,19 @@ func getDenomFromRegistry(chainName string) (string, error) {
 
 	return chain.Fees.FeeTokens[0].Denom, nil
 }
+
+// Quick way to parse the denom from the json
+// without worrying on the different message types
+// that the unsigned may have. In the future this
+// might be improved parsing the right msg type
+func parseDenomFromJson(tx []byte) (string, error) {
+	var anyJson map[string]interface{}
+	err := json.Unmarshal(tx, &anyJson)
+	if err != nil {
+		return "", err
+	}
+	body := anyJson["body"].(map[string]interface{})
+	denom := body["messages"].([]interface{})[0].(map[string]interface{})["amount"].([]interface{})[0].(map[string]interface{})["denom"].(string)
+	return denom, nil
+
+}


### PR DESCRIPTION
closes: #9 

Implemented logic to retrieve the denom from the configuration file, if it is not in the config file then try to pull it from the chain registry (https://github.com/cosmos/chain-registry). The denom is currently used in the `tx vote` and `tx withdraw`

> NOTE: The information from the chain registry could be leveraged one day for other features which is nice.
