### PR TITLE
Fixed the multisig list --all command

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -91,7 +91,7 @@ var signCmd = &cobra.Command{
 var listCmd = &cobra.Command{
 	Use:   "list <chain name> <key name>",
 	Short: "list items in a directory",
-	Args:  cobra.ExactArgs(2),
+	Args:  cobra.MaximumNArgs(2),
 	RunE:  cmdList,
 }
 

--- a/list.go
+++ b/list.go
@@ -39,7 +39,7 @@ func listAll() error {
 	}
 
 	last := ""
-	sep := "---------------------------------"
+	sep := "----------------------------------------"
 	fmt.Println(sep)
 	for _, f := range files {
 		fDir := filepath.Dir(f)


### PR DESCRIPTION
close: #23 

Fixed the command `multisig list --all`, now it will list everything in the S3 bucket.