### PR TITLE
Delete command for multisig (#29)

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -102,6 +102,13 @@ var broadcastCmd = &cobra.Command{
 	RunE:  cmdBroadcast,
 }
 
+var deleteCmd = &cobra.Command{
+	Use:   "delete <chain name> <key name>",
+	Short: "delete a tx",
+	Args:  cobra.ExactArgs(2),
+	RunE:  cmdDelete,
+}
+
 var rawCmd = &cobra.Command{
 	Use:   "raw <cmd>",
 	Short: "raw operations on the s3 bucket",
@@ -172,6 +179,7 @@ func init() {
 	rootCmd.AddCommand(listCmd)
 	rootCmd.AddCommand(broadcastCmd)
 	rootCmd.AddCommand(rawCmd)
+	rootCmd.AddCommand(deleteCmd)
 
 	// Raw commands
 	rawCmd.AddCommand(rawBech32Cmd)
@@ -207,4 +215,6 @@ func init() {
 	addListCmdFlags(listCmd)
 
 	addBroadcastCmdFlags(broadcastCmd)
+
+	addDeleteCmdFlags(deleteCmd)
 }

--- a/flags.go
+++ b/flags.go
@@ -34,3 +34,8 @@ func addBroadcastCmdFlags(cmd *cobra.Command) {
 	cmd.Flags().IntVarP(&flagTxIndex, "index", "i", 0, "index of the tx to broadcast")
 	// broacastCmd.Flags().StringVarP(&flagDescription, "description", "d", "", "description of the tx to be logged")
 }
+
+// addDeleteCmdFlags defines common flags to be used in the delete command
+func addDeleteCmdFlags(cmd *cobra.Command) {
+	cmd.Flags().IntVarP(&flagTxIndex, "index", "i", 0, "index of the tx to delete")
+}

--- a/list.go
+++ b/list.go
@@ -38,6 +38,12 @@ func listAll() error {
 		files = append(files, key)
 	}
 
+	// Check if there is anything in the bucket, if not then return
+	if len(files) == 0 {
+		fmt.Printf("no files in %s bucket, nothing to list\n", conf.AWS.Bucket)
+		return nil
+	}
+
 	last := ""
 	sep := "----------------------------------------"
 	fmt.Println(sep)


### PR DESCRIPTION
close: #29 

Implemented the `multisig delete` command to delete all files in one shot in a particular `chain/key/index` location.