### PR TITLE
Add description flag to the tx commands

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -201,6 +201,8 @@ func init() {
 	// Add flags to commands
 	addTxCmdCommonFlags(pushCmd)
 
+	addTxPushCmdCommonFlags(pushCmd)
+
 	addTxCmdCommonFlags(voteCmd)
 	addDenomFlags(voteCmd)
 

--- a/cmd.go
+++ b/cmd.go
@@ -201,8 +201,6 @@ func init() {
 	// Add flags to commands
 	addTxCmdCommonFlags(pushCmd)
 
-	addTxPushCmdCommonFlags(pushCmd)
-
 	addTxCmdCommonFlags(voteCmd)
 	addDenomFlags(voteCmd)
 

--- a/flags.go
+++ b/flags.go
@@ -9,11 +9,7 @@ func addTxCmdCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&flagNode, "node", "n", "", "tendermint rpc node to get sequence and account number from")
 	cmd.Flags().BoolVarP(&flagForce, "force", "f", false, "overwrite files already there")
 	cmd.Flags().BoolVarP(&flagAdditional, "additional", "x", false, "add additional txs with higher sequence number")
-}
-
-// addPTxPushCmdCommonFlags defines common flags to be reused in the tx push commands
-func addTxPushCmdCommonFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVarP(&flagDescription, "description", "d", "", "additional information about the transaction")
+	cmd.Flags().StringVarP(&flagDescription, "description", "i", "", "information about the transaction")
 }
 
 // addDenomFlags defines a denom flag to be reused across commands

--- a/flags.go
+++ b/flags.go
@@ -11,6 +11,11 @@ func addTxCmdCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&flagAdditional, "additional", "x", false, "add additional txs with higher sequence number")
 }
 
+// addPTxPushCmdCommonFlags defines common flags to be reused in the tx push commands
+func addTxPushCmdCommonFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&flagDescription, "description", "d", "", "additional information about the transaction")
+}
+
 // addDenomFlags defines a denom flag to be reused across commands
 func addDenomFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&flagDenom, "denom", "d", "", "fee denom, for offline creation")

--- a/main.go
+++ b/main.go
@@ -35,9 +35,10 @@ var (
 
 // Data we need for signers to sign a tx (eg. without access to a node)
 type SignData struct {
-	Account  int    `json:"account"`
-	Sequence int    `json:"sequence"`
-	ChainID  string `json:"chain-id"`
+	Account     int    `json:"account"`
+	Sequence    int    `json:"sequence"`
+	ChainID     string `json:"chain-id"`
+	Description string `json:"description"`
 }
 
 func main() {
@@ -547,9 +548,10 @@ func pushTx(chainName, keyName string, unsignedTxBytes []byte, cmd *cobra.Comman
 
 	// create and marshal the sign data
 	signData := SignData{
-		Account:  accountNum,
-		Sequence: sequenceNum,
-		ChainID:  chain.ID,
+		Account:     accountNum,
+		Sequence:    sequenceNum,
+		ChainID:     chain.ID,
+		Description: flagDescription,
 	}
 	signDataBytes, err := json.Marshal(signData)
 	if err != nil {


### PR DESCRIPTION
close: #37 

Implemented logic to allow the end user to add additional information about the transaction using a `--description` flag (or `-i`). The description information will be included in the `signdata.json` file and will provide additional information for whoever is also signing the transaction.

Tested and seem to work fine. Also tested a scenario where a user adds the description but the other user signing doesn't have the latest `multisig` binary and it still works (no breaking changes).