### PR TITLE
Support for different account types

### DIFF
--- a/main.go
+++ b/main.go
@@ -925,8 +925,7 @@ func parseTxResult(txResultBytes []byte) (int, string, error) {
 	return code, txhash, nil
 }
 
-// TODO can we get this more programmatically ?
-// Need to parse out the account and sequence number
+// Parse out the account and sequence number
 // Return: accountNumber, sequenceNumber, error
 func parseAccountQuery(queryResponseBytes []byte) (int, int, error) {
 	var (

--- a/types.go
+++ b/types.go
@@ -1,0 +1,60 @@
+package main
+
+type PeriodicVestingAccount struct {
+	Type               string `json:"@type"`
+	BaseVestingAccount struct {
+		BaseAccount struct {
+			Address string `json:"address"`
+			PubKey  struct {
+				Type       string `json:"@type"`
+				Threshold  int    `json:"threshold"`
+				PublicKeys []struct {
+					Type string `json:"@type"`
+					Key  string `json:"key"`
+				} `json:"public_keys"`
+			} `json:"pub_key"`
+			AccountNumber string `json:"account_number"`
+			Sequence      string `json:"sequence"`
+		} `json:"base_account"`
+		OriginalVesting []struct {
+			Denom  string `json:"denom"`
+			Amount string `json:"amount"`
+		} `json:"original_vesting"`
+		DelegatedFree []struct {
+			Denom  string `json:"denom"`
+			Amount string `json:"amount"`
+		} `json:"delegated_free"`
+		DelegatedVesting []struct {
+			Denom  string `json:"denom"`
+			Amount string `json:"amount"`
+		} `json:"delegated_vesting"`
+		EndTime string `json:"end_time"`
+	} `json:"base_vesting_account"`
+	StartTime      string `json:"start_time"`
+	VestingPeriods []struct {
+		Length string `json:"length"`
+		Amount []struct {
+			Denom  string `json:"denom"`
+			Amount string `json:"amount"`
+		} `json:"amount"`
+	} `json:"vesting_periods"`
+}
+
+type BaseAccount struct {
+	Type    string `json:"@type"`
+	Address string `json:"address"`
+	PubKey  struct {
+		Type       string `json:"@type"`
+		Threshold  int    `json:"threshold"`
+		PublicKeys []struct {
+			Type string `json:"@type"`
+			Key  string `json:"key"`
+		} `json:"public_keys"`
+	} `json:"pub_key"`
+	AccountNumber string `json:"account_number"`
+	Sequence      string `json:"sequence"`
+}
+
+type AccountType struct {
+	Type string `json:"@type"`
+}


### PR DESCRIPTION
close #21 

Changed logic to handle different account types `BaseAccount` and `PeriodicVestingAccount` returned when querying an account to find the account number and the sequence number. Changed the logic to parse string to marshal the json returned and access the account number and sequence programmatically. Tested and it's working