### PR TITLE
Use default values for gas and fees from the config file

### DIFF
--- a/config.go
+++ b/config.go
@@ -36,11 +36,12 @@ type AWS struct {
 // Config file
 type Config struct {
 	User           string
-	KeyringBackend string // TODO: how to support snake_case?
-
-	AWS    AWS
-	Keys   []Key
-	Chains []Chain
+	KeyringBackend string
+	DefaultFee     int64
+	DefaultGas     int64
+	AWS            AWS
+	Keys           []Key
+	Chains         []Chain
 }
 
 func (c *Config) GetChain(name string) (Chain, bool) {
@@ -76,6 +77,14 @@ func loadConfig(filename string) (*Config, error) {
 
 	if c.AWS.BucketRegion == "" {
 		c.AWS.BucketRegion = defaultBucketRegion
+	}
+
+	if c.DefaultGas == 0 {
+		c.DefaultGas = int64(defaultGas)
+	}
+
+	if c.DefaultFee == 0 {
+		c.DefaultFee = int64(defaultFee)
 	}
 
 	return c, nil

--- a/main.go
+++ b/main.go
@@ -925,8 +925,7 @@ func parseTxResult(txResultBytes []byte) (int, string, error) {
 	return code, txhash, nil
 }
 
-// TODO can we get this more programmatically ?
-// Need to parse out the account and sequence number
+// Parse out the account and sequence number
 // Return: accountNumber, sequenceNumber, error
 func parseAccountQuery(queryResponseBytes []byte) (int, int, error) {
 	var (

--- a/main.go
+++ b/main.go
@@ -31,6 +31,8 @@ var (
 	signDataJSON = "signdata.json"
 
 	defaultBucketRegion = "ca-central-1"
+	defaultFee          = 1000
+	defaultGas          = 300000
 )
 
 // Data we need for signers to sign a tx (eg. without access to a node)
@@ -167,8 +169,8 @@ func cmdWithdraw(cmd *cobra.Command, args []string) error {
 	}
 
 	// TODO: config ?
-	gas := 300000
-	fee := 10000
+	gas := defaultGas
+	fee := defaultFee
 
 	// gaiad tx gov vote <prop id> <option> --from <from> --generate-only
 	cmdArgs := []string{"tx", "distribution", "withdraw-all-rewards",
@@ -272,8 +274,8 @@ func cmdGrantAuthz(cmd *cobra.Command, args []string) error {
 	}
 
 	// TODO: config ?
-	gas := 300000
-	fee := 10000
+	gas := defaultGas
+	fee := defaultFee
 
 	// gaiad tx authz grant
 	cmdArgs := []string{"tx", "authz", "grant", grantee, "generic",
@@ -355,8 +357,8 @@ func cmdVote(cmd *cobra.Command, args []string) error {
 	}
 
 	// TODO: config ?
-	gas := 300000
-	fee := 10000
+	gas := defaultGas
+	fee := defaultFee
 
 	// gaiad tx gov vote <prop id> <option> --from <from> --generate-only
 	cmdArgs := []string{"tx", "gov", "vote", propID, voteOption,

--- a/main.go
+++ b/main.go
@@ -168,15 +168,11 @@ func cmdWithdraw(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// TODO: config ?
-	gas := defaultGas
-	fee := defaultFee
-
 	// gaiad tx gov vote <prop id> <option> --from <from> --generate-only
 	cmdArgs := []string{"tx", "distribution", "withdraw-all-rewards",
 		"--from", address,
-		"--fees", fmt.Sprintf("%d%s", fee, denom),
-		"--gas", fmt.Sprintf("%d", gas),
+		"--fees", fmt.Sprintf("%d%s", conf.DefaultFee, denom),
+		"--gas", fmt.Sprintf("%d", conf.DefaultGas),
 		"--generate-only",
 		"--chain-id", fmt.Sprintf("%s", chain.ID),
 	}
@@ -273,17 +269,13 @@ func cmdGrantAuthz(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// TODO: config ?
-	gas := defaultGas
-	fee := defaultFee
-
 	// gaiad tx authz grant
 	cmdArgs := []string{"tx", "authz", "grant", grantee, "generic",
 		"--expiration", fmt.Sprintf("%d", expireTimestamp),
 		"--msg-type", cosmosMsg,
 		"--from", address,
-		"--fees", fmt.Sprintf("%d%s", fee, denom),
-		"--gas", fmt.Sprintf("%d", gas),
+		"--fees", fmt.Sprintf("%d%s", conf.DefaultFee, denom),
+		"--gas", fmt.Sprintf("%d", conf.DefaultGas),
 		"--generate-only",
 		"--chain-id", fmt.Sprintf("%s", chain.ID),
 	}
@@ -356,15 +348,11 @@ func cmdVote(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// TODO: config ?
-	gas := defaultGas
-	fee := defaultFee
-
 	// gaiad tx gov vote <prop id> <option> --from <from> --generate-only
 	cmdArgs := []string{"tx", "gov", "vote", propID, voteOption,
 		"--from", address,
-		"--fees", fmt.Sprintf("%d%s", fee, denom),
-		"--gas", fmt.Sprintf("%d", gas),
+		"--fees", fmt.Sprintf("%d%s", conf.DefaultFee, denom),
+		"--gas", fmt.Sprintf("%d", conf.DefaultGas),
 		"--generate-only",
 		"--chain-id", fmt.Sprintf("%s", chain.ID),
 	}

--- a/types.go
+++ b/types.go
@@ -1,0 +1,60 @@
+package main
+
+type PeriodicVestingAccount struct {
+	Type               string `json:"@type"`
+	BaseVestingAccount struct {
+		BaseAccount struct {
+			Address string `json:"address"`
+			PubKey  struct {
+				Type       string `json:"@type"`
+				Threshold  int    `json:"threshold"`
+				PublicKeys []struct {
+					Type string `json:"@type"`
+					Key  string `json:"key"`
+				} `json:"public_keys"`
+			} `json:"pub_key"`
+			AccountNumber string `json:"account_number"`
+			Sequence      string `json:"sequence"`
+		} `json:"base_account"`
+		OriginalVesting []struct {
+			Denom  string `json:"denom"`
+			Amount string `json:"amount"`
+		} `json:"original_vesting"`
+		DelegatedFree []struct {
+			Denom  string `json:"denom"`
+			Amount string `json:"amount"`
+		} `json:"delegated_free"`
+		DelegatedVesting []struct {
+			Denom  string `json:"denom"`
+			Amount string `json:"amount"`
+		} `json:"delegated_vesting"`
+		EndTime string `json:"end_time"`
+	} `json:"base_vesting_account"`
+	StartTime      string `json:"start_time"`
+	VestingPeriods []struct {
+		Length string `json:"length"`
+		Amount []struct {
+			Denom  string `json:"denom"`
+			Amount string `json:"amount"`
+		} `json:"amount"`
+	} `json:"vesting_periods"`
+}
+
+type BaseAccount struct {
+	Type    string `json:"@type"`
+	Address string `json:"address"`
+	PubKey  struct {
+		Type       string `json:"@type"`
+		Threshold  int    `json:"threshold"`
+		PublicKeys []struct {
+			Type string `json:"@type"`
+			Key  string `json:"key"`
+		} `json:"public_keys"`
+	} `json:"pub_key"`
+	AccountNumber string `json:"account_number"`
+	Sequence      string `json:"sequence"`
+}
+
+type AccountType struct {
+	Type string `json:"@type"`
+}


### PR DESCRIPTION
close: #44 

Implemented logic to use the default values for `gas` and `fees` from the configuration. This replaces the old way where these values were hard-coded. This is more flexible since if the values would need to be updated you'd need to compile a new release with the default values. 