### PR TITLE
Command `tx authz revoke`

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -67,6 +67,25 @@ var authzGrantCmd = &cobra.Command{
 	RunE:          cmdGrantAuthz,
 }
 
+var authzRevokeCmd = &cobra.Command{
+	Use:   "revoke <chain name> <key name> <grantee address> <withdraw|commission|delegate|vote>",
+	Short: "generate an authz revoke tx and push it",
+	Long: "\nThis commands allows you to generate an unsigned tx to revoke an existing authorization " +
+		"to a 'grantee' address for a particular '<message-type>' (e.g. withdraw)\n " +
+		"multisig tx revoke cosmoshub my-key cosmos1adggsadfsadfffredffdssdf withdraw",
+	Args: func(cmd *cobra.Command, args []string) error {
+		numArgs := 4 // Update the number of arguments if command use changes
+		if len(args) != numArgs {
+			cmd.Help()
+			return fmt.Errorf("\n accepts %d arg(s), received %d", numArgs, len(args))
+		}
+		return nil
+	},
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE:          cmdRevokeAuthz,
+}
+
 var voteCmd = &cobra.Command{
 	Use:   "vote <chain name> <key name> <proposal number> <vote option (yes/no/veto/abstain)>",
 	Short: "generate a vote tx and push it",
@@ -197,6 +216,7 @@ func init() {
 
 	// Authz subcommands
 	authzCmd.AddCommand(authzGrantCmd)
+	authzCmd.AddCommand(authzRevokeCmd)
 
 	// Add flags to commands
 	addTxCmdCommonFlags(pushCmd)
@@ -209,6 +229,9 @@ func init() {
 
 	addTxCmdCommonFlags(authzGrantCmd)
 	addDenomFlags(authzGrantCmd)
+
+	addTxCmdCommonFlags(authzRevokeCmd)
+	addDenomFlags(authzRevokeCmd)
 
 	addSignCmdFlags(signCmd)
 

--- a/main.go
+++ b/main.go
@@ -300,6 +300,96 @@ func cmdGrantAuthz(cmd *cobra.Command, args []string) error {
 	return pushTx(chainName, keyName, unsignedBytes, cmd)
 }
 
+func cmdRevokeAuthz(cmd *cobra.Command, args []string) error {
+	chainName := args[0]
+	keyName := args[1]
+	grantee := args[2]
+
+	msgType := args[3]
+	// Parse message-type parameter and generate proper tx msg-type
+	// Only support the messages we need for now (withdraw, delegate, commission, vote)
+	var cosmosMsg string
+	switch msgType {
+	case "withdraw":
+		cosmosMsg = "/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward"
+	case "delegate":
+		cosmosMsg = "/cosmos.staking.v1beta1.MsgDelegate"
+	case "commission":
+		cosmosMsg = "/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission"
+	case "vote":
+		cosmosMsg = "/cosmos.gov.v1beta1.MsgVote"
+	default:
+		return fmt.Errorf("message type %s not supported", msgType)
+	}
+
+	conf, err := loadConfig(configFile)
+	if err != nil {
+		return err
+	}
+
+	chain, found := conf.GetChain(chainName)
+	if !found {
+		return fmt.Errorf("chain %s not found in config", chainName)
+	}
+	key, found := conf.GetKey(keyName)
+	if !found {
+		return fmt.Errorf("key %s not found in config", keyName)
+	}
+
+	// Use denom from flag if specified, if not, then try
+	// to retrieve it from the config, if not in the config
+	// try to retrieve from the chain registry.
+	var denom string
+	isDenomSet := cmd.Flags().Changed("denom")
+	if isDenomSet {
+		denom = flagDenom
+	} else {
+		denom, err = getDenom(conf, chainName)
+		if err != nil {
+			return fmt.Errorf("denom not found in config or chain registry: %s", err)
+		}
+	}
+
+	nodeAddress := chain.Node
+	if flagNode != "" {
+		nodeAddress = flagNode
+	}
+
+	binary := chain.Binary
+	address, err := bech32ify(key.Address, chain.Prefix)
+	if err != nil {
+		return err
+	}
+
+	// gaiad tx authz grant
+	cmdArgs := []string{"tx", "authz", "revoke", grantee, cosmosMsg,
+		"--from", address,
+		"--fees", fmt.Sprintf("%d%s", conf.DefaultFee, denom),
+		"--gas", fmt.Sprintf("%d", conf.DefaultGas),
+		"--generate-only",
+		"--chain-id", fmt.Sprintf("%s", chain.ID),
+	}
+
+	if nodeAddress != "" {
+		cmdArgs = append(cmdArgs, "--node", nodeAddress)
+	}
+
+	execCmd := exec.Command(binary, cmdArgs...)
+	fmt.Println(execCmd)
+	unsignedBytes, err := execCmd.CombinedOutput()
+	if err != nil {
+		fmt.Println("-----------------------------------------------------------------")
+		fmt.Println("call failed")
+		fmt.Println("-----------------------------------------------------------------")
+		fmt.Println(execCmd)
+		fmt.Println(string(unsignedBytes))
+		return err
+	}
+	fmt.Println(string(unsignedBytes))
+
+	return pushTx(chainName, keyName, unsignedBytes, cmd)
+}
+
 func cmdVote(cmd *cobra.Command, args []string) error {
 	chainName := args[0]
 	keyName := args[1]


### PR DESCRIPTION
close: #18 

Added command to allow multisig to submit a tx to revoke a authz permission for a particular message type (e.g. vote)