### PR TITLE
Adding -fees and --gas params for `tx` commands

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -204,6 +204,8 @@ var (
 	flagDenom       string
 	flagTxIndex     int
 	flagConfigPath  string
+	flagGas         int
+	flagFees        string
 )
 
 func init() {

--- a/config.go
+++ b/config.go
@@ -11,6 +11,11 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/bech32"
 )
 
+var (
+	defaultBucketRegion = "ca-central-1"
+	defaultGas          = 300000
+)
+
 // A chain we sign txs on
 type Chain struct {
 	Name   string // chain name
@@ -41,7 +46,6 @@ type AWS struct {
 type Config struct {
 	User           string
 	KeyringBackend string
-	DefaultFee     int64
 	DefaultGas     int64
 	AWS            AWS
 	Keys           []Key
@@ -93,14 +97,6 @@ func loadConfig(filename string) (*Config, error) {
 
 	if c.AWS.BucketRegion == "" {
 		c.AWS.BucketRegion = defaultBucketRegion
-	}
-
-	if c.DefaultGas == 0 {
-		c.DefaultGas = int64(defaultGas)
-	}
-
-	if c.DefaultFee == 0 {
-		c.DefaultFee = int64(defaultFee)
 	}
 
 	return c, nil

--- a/flags.go
+++ b/flags.go
@@ -10,6 +10,8 @@ func addTxCmdCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&flagForce, "force", "f", false, "overwrite files already there")
 	cmd.Flags().BoolVarP(&flagAdditional, "additional", "x", false, "add additional txs with higher sequence number")
 	cmd.Flags().StringVarP(&flagDescription, "description", "i", "", "information about the transaction")
+	cmd.Flags().IntVarP(&flagGas, "gas", "", 0, "gas limit for the transaction, e.g. 200000")
+	cmd.Flags().StringVarP(&flagFees, "fees", "", "", "fees to pay for the transaction, e.g. 10uatom")
 }
 
 // addDenomFlags defines a denom flag to be reused across commands
@@ -33,7 +35,6 @@ func addListCmdFlags(cmd *cobra.Command) {
 func addBroadcastCmdFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&flagNode, "node", "n", "", "node address to broadcast too. flag overrides config")
 	cmd.Flags().IntVarP(&flagTxIndex, "index", "i", 0, "index of the tx to broadcast")
-	// broacastCmd.Flags().StringVarP(&flagDescription, "description", "d", "", "description of the tx to be logged")
 }
 
 // addDeleteCmdFlags defines common flags to be used in the delete command


### PR DESCRIPTION
Added two new parameters for `multisig tx` commands. 

```   
--fees string          fees to pay for the transaction, e.g. 10uatom

--gas int              gas limit for the transaction, e.g. 200000
```

The `--gas` parameter is optional. If not specified it will try to use the value from the config `defaultGas`. If the config doesn't have it, it will use a hard-coded value of `300000`

The `--fees` parameter is required for all transactions. User needs to specify the amount + denom (e.g. 1000uatom).

The previous logic to use a default fee has been removed since it could create dangerous situations. For example, multisig supports chains that have a 18 exponent (e.g. evmos) and 6 exponent (e.g. gaiad). In the past there was not way to specify the fees from the command line so a user would need to change the value in the config file. But that could lead to a dangerous situation that a user could submit a transaction to a 18 exponent chain than later to a 6 exponent one but the fees would be too high and user would end up paying a very high fee. So the logic to use a `defaultFees` from the config file is not valid anymore. 