### PR TITLE
Flag to specify the local multisig key name in the broadcast command

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,13 +333,15 @@ Where `--from` is the name of the key in your local keystore, the same as you wo
 To assemble the signed tx and broadcast it, run:
 
 ```
-multisig broadcast <chain name> <key name> --index <tx index>
+multisig broadcast <chain name> <key name>
 ```
 
-Where the `--index` is the tx index to sign for (default 0). Note txs must be
-broadcast in order.
+The `--index` flag can be used to sign a transaction under that index (default 0). Note that transactions must be
+broadcast in the index sequential order (e.g. 0, 1, 2).
 
 The `--node` flag can be used to overwrite what's in the config file.
+
+The `--key` flag can be used to specify the local multisig key name.
 
 ## Raw
 

--- a/cmd.go
+++ b/cmd.go
@@ -206,6 +206,7 @@ var (
 	flagConfigPath  string
 	flagGas         int
 	flagFees        string
+	flagMultisigKey string
 )
 
 func init() {

--- a/flags.go
+++ b/flags.go
@@ -39,6 +39,7 @@ func addListCmdFlags(cmd *cobra.Command) {
 func addBroadcastCmdFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&flagNode, "node", "n", "", "node address to broadcast too. flag overrides config")
 	cmd.Flags().IntVarP(&flagTxIndex, "index", "i", 0, "index of the tx to broadcast")
+	cmd.Flags().StringVarP(&flagMultisigKey, "key", "k", "", "name of the local multisig key name, flag overrides the config")
 }
 
 // addDeleteCmdFlags defines common flags to be used in the delete command

--- a/main.go
+++ b/main.go
@@ -954,7 +954,7 @@ func cmdBroadcast(cobraCmd *cobra.Command, args []string) error {
 	}
 
 	// read and unmarshal the sign data
-	signDataBytes, err := ioutil.ReadFile(signDataJSON)
+	signDataBytes, err := os.ReadFile(signDataJSON)
 	if err != nil {
 		return err
 	}
@@ -972,6 +972,9 @@ func cmdBroadcast(cobraCmd *cobra.Command, args []string) error {
 	backend := conf.KeyringBackend
 	// TODO: can I used the address directly here instead ?
 	localMultisigName := key.LocalName
+	if localMultisigName == "" {
+		return fmt.Errorf("localname property for %s key entry in the configuration file is empty", key.Name)
+	}
 
 	// gaiad tx multisign unsigned.json <local multisig name> <sig 1> <sig 2> ...  --account-number <acc> --sequence <seq> --chain-id <id>
 	cmdArgs := []string{"tx", "multisign", unsignedFileName, localMultisigName}
@@ -1002,7 +1005,7 @@ func cmdBroadcast(cobraCmd *cobra.Command, args []string) error {
 	fmt.Println(cmd)
 	fmt.Println(string(b))
 
-	if err := ioutil.WriteFile(signedJSON, b, 0666); err != nil {
+	if err := os.WriteFile(signedJSON, b, 0666); err != nil {
 		return err
 	}
 

--- a/main.go
+++ b/main.go
@@ -970,10 +970,18 @@ func cmdBroadcast(cobraCmd *cobra.Command, args []string) error {
 	chainID := signData.ChainID
 	unsignedFileName := unsignedJSON
 	backend := conf.KeyringBackend
-	// TODO: can I used the address directly here instead ?
-	localMultisigName := key.LocalName
-	if localMultisigName == "" {
-		return fmt.Errorf("localname property for %s key entry in the configuration file is empty", key.Name)
+
+	// Check if the local multisig key name was passed as a parameter,
+	// if not then check the config file, if also not in the file
+	// then return an error
+	var localMultisigName string
+	if cobraCmd.Flags().Changed("key") {
+		localMultisigName = flagMultisigKey
+	} else {
+		localMultisigName := key.LocalName
+		if localMultisigName == "" {
+			return fmt.Errorf("localname property for %s key entry in the configuration file is empty", key.Name)
+		}
 	}
 
 	// gaiad tx multisign unsigned.json <local multisig name> <sig 1> <sig 2> ...  --account-number <acc> --sequence <seq> --chain-id <id>


### PR DESCRIPTION
close: #53 

Added logic to allow a user to specify a `--key` flag to the `multisig broadcast` command.