### PR TITLE
fix local name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## Unreleased
+
+#### BUG FIXES
+
+- `localname` settings in the config were not being applied properly, and would
+  result in errors when running `multisig broadcast`
+  ([#85](https://github.com/informalsystems/multisig/pull/85))
+
+
 ## v0.4.0
 *December 20th, 2022*
 

--- a/main.go
+++ b/main.go
@@ -978,10 +978,10 @@ func cmdBroadcast(cobraCmd *cobra.Command, args []string) error {
 	if cobraCmd.Flags().Changed("key") {
 		localMultisigName = flagMultisigKey
 	} else {
-		localMultisigName := key.LocalName
-		if localMultisigName == "" {
-			return fmt.Errorf("localname property for %s key entry in the configuration file is empty", key.Name)
-		}
+		localMultisigName = key.LocalName
+	}
+	if localMultisigName == "" {
+		return fmt.Errorf("localname property for %s key entry in the configuration file is empty", key.Name)
 	}
 
 	// gaiad tx multisign unsigned.json <local multisig name> <sig 1> <sig 2> ...  --account-number <acc> --sequence <seq> --chain-id <id>


### PR DESCRIPTION
The `localMultisigName` was being set with `:=` inside the `if` block so it was being setup as a local variable and thus outside the if/else block the value of `localMultisigName` was empty, so it was trying to run the `multisign` command with an empty value for the multisig.

The error was not catching it since the value was set inside the if/else block. With the error check outside the block, it would catch it. Fixed by changing `:=` to `=`