### PR TITLE
Add support for custom `--home` when signing/broadcasting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## Unreleased
+
+#### BUG FIXES
+
+- `localname` settings in the config were not being applied properly, and would
+  result in errors when running `multisig broadcast`
+  ([#85](https://github.com/informalsystems/multisig/pull/85))
+
+
 ## v0.4.0
 *December 20th, 2022*
 

--- a/cmd.go
+++ b/cmd.go
@@ -207,6 +207,7 @@ var (
 	flagGas         int
 	flagFees        string
 	flagMultisigKey string
+	flagHomePath    string
 )
 
 func init() {

--- a/flags.go
+++ b/flags.go
@@ -50,4 +50,5 @@ func addDeleteCmdFlags(cmd *cobra.Command) {
 // addGlobalFlags defines flags to be used regardless of the command used
 func addGlobalFlags(cmd *cobra.Command) {
 	rootCmd.PersistentFlags().StringVarP(&flagConfigPath, "config", "c", "", "custom config path")
+	rootCmd.PersistentFlags().StringVarP(&flagHomePath, "home", "", "", "custom home path for keystore for sign and broadcast cmds")
 }

--- a/main.go
+++ b/main.go
@@ -833,6 +833,9 @@ func cmdSign(cobraCmd *cobra.Command, args []string) error {
 		"--offline",
 	}
 	cmdArgs = append(cmdArgs, "--keyring-backend", backend)
+	if flagHomePath != "" {
+		cmdArgs = append(cmdArgs, "--home", flagHomePath)
+	}
 	cmd := exec.Command(binary, cmdArgs...)
 	b, err := cmd.CombinedOutput()
 	if err != nil {
@@ -998,6 +1001,9 @@ func cmdBroadcast(cobraCmd *cobra.Command, args []string) error {
 	}
 	if nodeAddress != "" {
 		cmdArgs = append(cmdArgs, "--node", nodeAddress)
+	}
+	if flagHomePath != "" {
+		cmdArgs = append(cmdArgs, "--home", flagHomePath)
 	}
 
 	cmd := exec.Command(binary, cmdArgs...)

--- a/main.go
+++ b/main.go
@@ -978,10 +978,10 @@ func cmdBroadcast(cobraCmd *cobra.Command, args []string) error {
 	if cobraCmd.Flags().Changed("key") {
 		localMultisigName = flagMultisigKey
 	} else {
-		localMultisigName := key.LocalName
-		if localMultisigName == "" {
-			return fmt.Errorf("localname property for %s key entry in the configuration file is empty", key.Name)
-		}
+		localMultisigName = key.LocalName
+	}
+	if localMultisigName == "" {
+		return fmt.Errorf("localname property for %s key entry in the configuration file is empty", key.Name)
 	}
 
 	// gaiad tx multisign unsigned.json <local multisig name> <sig 1> <sig 2> ...  --account-number <acc> --sequence <seq> --chain-id <id>


### PR DESCRIPTION
Merge #85 first 

Allow specifying `--home` for signing and broadcasting which enables different keystores to be used.

I was using the same keystore for different binaries but with v0.46 of the SDK my keystore got upgraded so now I need to maintain a separate keystore for v0.45 binaries, so I need to be able to tell multisig where to find it.