### PR TITLE
Add unbond and redelegate messages to authz grant and revoke commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Quick summary, with much more below:
   trusted
 - `multisig tx push` takes an unsigned tx file and pushes it to the s3 directory along with data needed for signing (eg. account number, sequence number, chain id)
 - `multisig tx vote` generate a vote tx and push it to s3 directory
-- `multisig tx authz` generate an authz grant tx (delegate, withdraw, commission, vote) or revoke an authz authorization
+- `multisig tx authz` generate an authz grant tx (delegate, withdraw, commission, vote, unbond, redelegate) or revoke an authz authorization
 - `multisig sign` fetches the unsigned tx and signing data for a given chain and key, signs it using the correct binary (eg. `gaiad tx sign unsigned.json ...`), and pushes the signature back to the directory
 - `multisig list` lists the files in a directory so you can see who has signed
 - `multisig broadcast` fetches all the data from a directory, compiles the signed tx (eg. `gaiad tx multisign unsigned.json ...`), broadcasts it using the configured node, and deletes all the files from the directory so signing can start fresh for a new tx

--- a/cmd.go
+++ b/cmd.go
@@ -45,7 +45,7 @@ var authzCmd = &cobra.Command{
 }
 
 var authzGrantCmd = &cobra.Command{
-	Use:   "grant <chain name> <key name> <grantee address> <withdraw|commission|delegate|vote> <expiration days>",
+	Use:   "grant <chain name> <key name> <grantee address> <withdraw|commission|delegate|vote|unbond|redelegate> <expiration days>",
 	Short: "generate an authz grant tx and push it",
 	Long: "\nThis commands allows you to generate an unsigned tx to grant authorization " +
 		"to a 'grantee' address that will be able to execute transactions as specified in " +
@@ -68,7 +68,7 @@ var authzGrantCmd = &cobra.Command{
 }
 
 var authzRevokeCmd = &cobra.Command{
-	Use:   "revoke <chain name> <key name> <grantee address> <withdraw|commission|delegate|vote>",
+	Use:   "revoke <chain name> <key name> <grantee address> <withdraw|commission|delegate|vote|unbond|redelegate>",
 	Short: "generate an authz revoke tx and push it",
 	Long: "\nThis commands allows you to generate an unsigned tx to revoke an existing authorization " +
 		"to a 'grantee' address for a particular '<message-type>' (e.g. withdraw)\n " +

--- a/main.go
+++ b/main.go
@@ -323,6 +323,10 @@ func cmdGrantAuthz(cmd *cobra.Command, args []string) error {
 		cosmosMsg = "/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission"
 	case "vote":
 		cosmosMsg = "/cosmos.gov.v1beta1.MsgVote"
+	case "unbond":
+		cosmosMsg = "/cosmos.staking.v1beta1.MsgUndelegate"
+	case "redelegate":
+		cosmosMsg = "/cosmos.staking.v1beta1.MsgBeginRedelegate"
 	default:
 		return fmt.Errorf("message type %s not supported", msgType)
 	}
@@ -416,6 +420,10 @@ func cmdRevokeAuthz(cmd *cobra.Command, args []string) error {
 		cosmosMsg = "/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission"
 	case "vote":
 		cosmosMsg = "/cosmos.gov.v1beta1.MsgVote"
+	case "unbond":
+		cosmosMsg = "/cosmos.staking.v1beta1.MsgUndelegate"
+	case "redelegate":
+		cosmosMsg = "/cosmos.staking.v1beta1.MsgBeginRedelegate"
 	default:
 		return fmt.Errorf("message type %s not supported", msgType)
 	}


### PR DESCRIPTION
Adds unbond `/cosmos.staking.v1beta1.MsgUndelegate` and redelegate `/cosmos.staking.v1beta1.MsgBeginRedelegate` messages to the authz grant and revoke commands.