### PR TITLE
Partially update multisig to SDK 0.50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## v0.4.2
+*May 19th, 2024*
+
+### Improvements
+- multisig is able to process `BaseAccount` types from SDK v0.50.*
+- refactor account type processing to improve readability and remove hardcoded version from type URL
+
 ## v0.4.1
 *April 16th, 2024*
 

--- a/cmd.go
+++ b/cmd.go
@@ -7,7 +7,7 @@ import (
 
 // VERSION TODO: something more intelligent
 // Remember to change this every time ...
-const VERSION = "0.4.1"
+const VERSION = "0.4.2"
 
 var rootCmd = &cobra.Command{
 	Use:     "multisig",

--- a/http.go
+++ b/http.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"time"
+)
+
+func NewHttpClient() (client *http.Client) {
+	client = &http.Client{Timeout: 10 * time.Second}
+	return
+}
+
+func HttpGet(url string, client *http.Client) (body []byte, err error) {
+	var req *http.Request
+	var res *http.Response
+
+	req, err = http.NewRequest("GET", url, nil)
+	if err != nil {
+		return
+	}
+
+	res, err = client.Do(req)
+	if err != nil {
+		return
+	}
+
+	defer func(Body io.ReadCloser) {
+		err := Body.Close()
+		if err != nil {
+			return
+		}
+	}(res.Body)
+
+	body, err = io.ReadAll(res.Body)
+
+	return
+}

--- a/main.go
+++ b/main.go
@@ -1137,108 +1137,98 @@ func parseTxResult(txResultBytes []byte) (int, string, error) {
 
 // Parse out the account and sequence number
 // Return: accountNumber, sequenceNumber, error
-func parseAccountQuery(queryResponseBytes []byte) (int, int, error) {
-	var (
-		accInt   int = 0
-		seqInt   int = 0
-		acctType AccountType
-	)
-
-	_ = json.Unmarshal(queryResponseBytes, &acctType)
-
-	if acctType.Type == "/cosmos.auth.v1beta1.BaseAccount" {
-		var ba BaseAccount
-		err := json.Unmarshal(queryResponseBytes, &ba)
-		if err != nil {
-			return 0, 0, fmt.Errorf("error un-marshalling base account")
-		}
-		accInt, err := strconv.Atoi(ba.AccountNumber)
-		if err != nil {
-			return 0, 0, fmt.Errorf("account number is not an integer")
-		}
-		seqInt, err := strconv.Atoi(ba.Sequence)
-		if err != nil {
-			return 0, 0, fmt.Errorf("sequence number is not an integer")
-		}
-		return accInt, seqInt, nil
-	} else if acctType.Type == "/cosmos.vesting.v1beta1.PeriodicVestingAccount" {
-		var pva PeriodicVestingAccount
-		err := json.Unmarshal(queryResponseBytes, &pva)
-		if err != nil {
-			return 0, 0, fmt.Errorf("error un-marshalling periodic vesting account")
-		}
-		accInt, err := strconv.Atoi(pva.BaseVestingAccount.BaseAccount.AccountNumber)
-		if err != nil {
-			return 0, 0, fmt.Errorf("account number is not an integer")
-		}
-		seqInt, err := strconv.Atoi(pva.BaseVestingAccount.BaseAccount.Sequence)
-		if err != nil {
-			return 0, 0, fmt.Errorf("sequence number is not an integer")
-		}
-		return accInt, seqInt, nil
-	} else if acctType.Type == "/cosmos.vesting.v1beta1.ContinuousVestingAccount" {
-		var cva ContinuousVestingAccount
-		err := json.Unmarshal(queryResponseBytes, &cva)
-		if err != nil {
-			return 0, 0, fmt.Errorf("error un-marshalling continuous vesting account")
-		}
-		accInt, err := strconv.Atoi(cva.BaseVestingAccount.BaseAccount.AccountNumber)
-		if err != nil {
-			return 0, 0, fmt.Errorf("account number is not an integer")
-		}
-		seqInt, err := strconv.Atoi(cva.BaseVestingAccount.BaseAccount.Sequence)
-		if err != nil {
-			return 0, 0, fmt.Errorf("sequence number is not an integer")
-		}
-		return accInt, seqInt, nil
-	} else if acctType.Type == "/stride.vesting.StridePeriodicVestingAccount" {
-		var spva StridePeriodicVestingAccount
-		err := json.Unmarshal(queryResponseBytes, &spva)
-		if err != nil {
-			return 0, 0, fmt.Errorf("error un-marshalling Stride Periodic Vesting Account account")
-		}
-		accInt, err := strconv.Atoi(spva.BaseVestingAccount.BaseAccount.AccountNumber)
-		if err != nil {
-			return 0, 0, fmt.Errorf("account number is not an integer")
-		}
-		seqInt, err := strconv.Atoi(spva.BaseVestingAccount.BaseAccount.Sequence)
-		if err != nil {
-			return 0, 0, fmt.Errorf("sequence number is not an integer")
-		}
-		return accInt, seqInt, nil
-	} else if acctType.Type == "/cosmos.vesting.v1beta1.DelayedVestingAccount" {
-		var dva DelayedVestingAccount
-		err := json.Unmarshal(queryResponseBytes, &dva)
-		if err != nil {
-			return 0, 0, fmt.Errorf("error un-marshalling Stride Periodic Vesting Account account")
-		}
-		accInt, err := strconv.Atoi(dva.BaseVestingAccount.BaseAccount.AccountNumber)
-		if err != nil {
-			return 0, 0, fmt.Errorf("account number is not an integer")
-		}
-		seqInt, err := strconv.Atoi(dva.BaseVestingAccount.BaseAccount.Sequence)
-		if err != nil {
-			return 0, 0, fmt.Errorf("sequence number is not an integer")
-		}
-		return accInt, seqInt, nil
-	} else if strings.Contains(acctType.Type, "EthAccount") {
-		var eth EthAccount
-		err := json.Unmarshal(queryResponseBytes, &eth)
-		if err != nil {
-			return 0, 0, fmt.Errorf("error un-marshalling ethermint account")
-		}
-		accInt, err := strconv.Atoi(eth.BaseAccount.AccountNumber)
-		if err != nil {
-			return 0, 0, fmt.Errorf("account number is not an integer")
-		}
-		seqInt, err := strconv.Atoi(eth.BaseAccount.Sequence)
-		if err != nil {
-			return 0, 0, fmt.Errorf("sequence number is not an integer")
-		}
-		return accInt, seqInt, nil
+func parseAccountQueryResponse(queryResponseBytes []byte, sdkVersion string) (int, int, error) {
+	//TODO: obviously this is an ugly hack for v0.50. Need to do something better
+	if strings.Contains(sdkVersion, "v0.50") {
+		return parseAcctByType50(queryResponseBytes)
 	} else {
-		return accInt, seqInt, fmt.Errorf("cannot parse account type")
+		return parseAcctByType(queryResponseBytes)
 	}
+}
+
+func convertAcctDetails(acctSeq string, acctNum string) (int, int, error) {
+	accInt, err := strconv.Atoi(acctSeq)
+	if err != nil {
+		return 0, 0, fmt.Errorf("account number is not an integer")
+	}
+	seqInt, err := strconv.Atoi(acctNum)
+	if err != nil {
+		return 0, 0, fmt.Errorf("sequence number is not an integer")
+	}
+	return accInt, seqInt, nil
+}
+
+func parseAcctByType50(respBytes []byte) (int, int, error) {
+	var acctType AcctType50
+	err := json.Unmarshal(respBytes, &acctType)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to unmarshal account type: %s", err)
+	}
+
+	switch {
+	case strings.Contains(acctType.Account.Type, "BaseAccount"):
+		var ba BaseAccount50
+		err = json.Unmarshal(respBytes, &ba)
+		if err != nil {
+			return 0, 0, fmt.Errorf("failed to unmarshal base account (SDK v0.50): %s", err)
+		}
+		return convertAcctDetails(ba.Account.Value.Sequence, ba.Account.Value.AccountNumber)
+	default:
+		return 0, 0, fmt.Errorf("unknown account type (SDK v0.50): %s", acctType.Account.Type)
+	}
+}
+
+func parseAcctByType(respBytes []byte) (int, int, error) {
+	var acctType AccountType
+	err := json.Unmarshal(respBytes, &acctType)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to unmarshal account type: %s", err)
+	}
+
+	switch {
+	case strings.Contains(acctType.Type, "BaseAccount"):
+		var ba BaseAccount
+		err = json.Unmarshal(respBytes, &ba)
+		if err != nil {
+			return 0, 0, fmt.Errorf("failed to unmarshal base account: %s", err)
+		}
+		return convertAcctDetails(ba.Sequence, ba.AccountNumber)
+	case strings.Contains(acctType.Type, "PeriodicVestingAccount"):
+		var pva PeriodicVestingAccount
+		err = json.Unmarshal(respBytes, &pva)
+		if err != nil {
+			return 0, 0, fmt.Errorf("failed to unmarshal periodic vesting account: %s", err)
+		}
+		return convertAcctDetails(pva.BaseVestingAccount.BaseAccount.Sequence, pva.BaseVestingAccount.BaseAccount.AccountNumber)
+	case strings.Contains(acctType.Type, "ContinuousVestingAccount"):
+		var cva ContinuousVestingAccount
+		err = json.Unmarshal(respBytes, &cva)
+		if err != nil {
+			return 0, 0, fmt.Errorf("failed to unmarshal continuous vesting account: %s", err)
+		}
+		return convertAcctDetails(cva.BaseVestingAccount.BaseAccount.Sequence, cva.BaseVestingAccount.BaseAccount.AccountNumber)
+	case strings.Contains(acctType.Type, "DelayedVestingAccount"):
+		var dva DelayedVestingAccount
+		err = json.Unmarshal(respBytes, &dva)
+		if err != nil {
+			return 0, 0, fmt.Errorf("failed to unmarshal delayed vesting account: %s", err)
+		}
+		return convertAcctDetails(dva.BaseVestingAccount.BaseAccount.Sequence, dva.BaseVestingAccount.BaseAccount.AccountNumber)
+	case strings.Contains(acctType.Type, "StridePeriodicVestingAccount"):
+		var spva StridePeriodicVestingAccount
+		err = json.Unmarshal(respBytes, &spva)
+		if err != nil {
+			return 0, 0, fmt.Errorf("failed to unmarshal stride periodic vesting account: %s", err)
+		}
+		return convertAcctDetails(spva.BaseVestingAccount.BaseAccount.Sequence, spva.BaseVestingAccount.BaseAccount.AccountNumber)
+	case strings.Contains(acctType.Type, "EthAccount"):
+		var ea EthAccount
+		err = json.Unmarshal(respBytes, &ea)
+		if err != nil {
+			return 0, 0, fmt.Errorf("failed to unmarshal eth account: %s", err)
+		}
+	}
+	return 0, 0, fmt.Errorf("unknown account type: %s", acctType.Type)
 }
 
 // Return: accountNumber, sequenceNumber, error
@@ -1264,7 +1254,7 @@ func getAccSeq(binary, addr, node string, sdkVersion string) (int, int, error) {
 	fmt.Println(cmd)
 	fmt.Println(string(b))
 
-	return parseAccountQuery(b)
+	return parseAccountQueryResponse(b, sdkVersion)
 }
 
 // Get account balance for a particular denom

--- a/main.go
+++ b/main.go
@@ -1147,11 +1147,11 @@ func parseAccountQueryResponse(queryResponseBytes []byte, sdkVersion string) (in
 }
 
 func convertAcctDetails(acctSeq string, acctNum string) (int, int, error) {
-	accInt, err := strconv.Atoi(acctSeq)
+	accInt, err := strconv.Atoi(acctNum)
 	if err != nil {
 		return 0, 0, fmt.Errorf("account number is not an integer")
 	}
-	seqInt, err := strconv.Atoi(acctNum)
+	seqInt, err := strconv.Atoi(acctSeq)
 	if err != nil {
 		return 0, 0, fmt.Errorf("sequence number is not an integer")
 	}

--- a/net_info.go
+++ b/net_info.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 )
@@ -15,11 +16,13 @@ func GetNodeInfo(chain Chain, client *http.Client) (response NodeInfo, err error
 	url := strings.ReplaceAll(httpUrl, "rpc", "rest") + "/cosmos/base/tendermint/v1beta1/node_info"
 	body, err = HttpGet(url, client)
 	if err != nil {
+		err = fmt.Errorf("node info query failed: %s", err)
 		return
 	}
 
 	err = json.Unmarshal(body, &response)
 	if err != nil {
+		err = fmt.Errorf("node info query failed: %s", err)
 		return
 	}
 

--- a/net_info.go
+++ b/net_info.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+func GetNodeInfo(chain Chain, client *http.Client) (response NodeInfo, err error) {
+	var body []byte
+
+	// TODO: replace these hacks with a more elegant handling of the node endpoints and protocol
+	httpUrl := strings.ReplaceAll(chain.Node, "tcp://", "http://")
+
+	url := strings.ReplaceAll(httpUrl, "rpc", "rest") + "/cosmos/base/tendermint/v1beta1/node_info"
+	body, err = HttpGet(url, client)
+	if err != nil {
+		return
+	}
+
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		return
+	}
+
+	return
+}

--- a/types.go
+++ b/types.go
@@ -180,3 +180,39 @@ type AccountBalance struct {
 		Total   string      `json:"total"`
 	} `json:"pagination"`
 }
+
+type ApplicationVersion struct {
+	Name      string `json:"name"`
+	AppName   string `json:"app_name"`
+	Version   string `json:"version"`
+	GitCommit string `json:"git_commit"`
+	BuildTags string `json:"build_tags"`
+	GoVersion string `json:"go_version"`
+	BuildDeps []struct {
+		Path    string `json:"path"`
+		Version string `json:"version"`
+		Sum     string `json:"sum"`
+	} `json:"build_deps"`
+	CosmosSdkVersion string `json:"cosmos_sdk_version"`
+}
+
+type NodeInfo struct {
+	DefaultNodeInfo struct {
+		ProtocolVersion struct {
+			P2P   string `json:"p2p"`
+			Block string `json:"block"`
+			App   string `json:"app"`
+		} `json:"protocol_version"`
+		DefaultNodeId string `json:"default_node_id"`
+		ListenAddress string `json:"listen_address"`
+		Network       string `json:"network"`
+		Version       string `json:"version"`
+		Channels      string `json:"channels"`
+		Moniker       string `json:"moniker"`
+		Other         struct {
+			TxIndex    string `json:"tx_index"`
+			RpcAddress string `json:"rpc_address"`
+		} `json:"other"`
+	} `json:"default_node_info"`
+	ApplicationVersion ApplicationVersion `json:"application_version"`
+}

--- a/types.go
+++ b/types.go
@@ -170,6 +170,33 @@ type AccountType struct {
 	Type string `json:"@type"`
 }
 
+type AcctType50 struct {
+	Account struct {
+		Type string `json:"type"`
+	}
+}
+
+type BaseAccount50 struct {
+	Account struct {
+		Type  string `json:"type"`
+		Value struct {
+			Address   string `json:"address"`
+			PublicKey struct {
+				Type  string `json:"type"`
+				Value struct {
+					Threshold string `json:"threshold"`
+					PubKeys   []struct {
+						Type  string `json:"type"`
+						Value string `json:"value"`
+					} `json:"pubkeys"`
+				}
+			}
+			AccountNumber string `json:"account_number"`
+			Sequence      string `json:"sequence"`
+		} `json:"value"`
+	} `json:"account"`
+}
+
 type AccountBalance struct {
 	Balances []struct {
 		Denom  string `json:"denom"`

--- a/util.go
+++ b/util.go
@@ -138,3 +138,12 @@ func parseDenomFromJson(tx []byte) (string, error) {
 	// in case cannot find the denom value in the json, return an error
 	return "", fmt.Errorf("cannot parse json, cannot find denom value")
 }
+
+func parseSdkVersionFromJson(nodeInfo NodeInfo) (string, error) {
+	for _, dep := range nodeInfo.ApplicationVersion.BuildDeps {
+		if dep.Path == "github.com/cosmos/cosmos-sdk" {
+			return dep.Version, nil
+		}
+	}
+	return "", errors.New(fmt.Sprintf("cannot parse sdk version, cannot find sdk version value"))
+}


### PR DESCRIPTION
There have been CLI and type changes in SDK 50 which break multisig. This PR aims to fix these issues through the following:

- [ ] detect which version of the sdk the chain is on
- [ ] handle `BaseAccount` from SDK v0.50.*